### PR TITLE
[Feature] withDeploy flag to enable deploy build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 .eslintcache
 .env
 node_modules
+/.idea

--- a/src/get-url.ts
+++ b/src/get-url.ts
@@ -1,12 +1,24 @@
 export default function getURL(
   os: string,
   arch: string,
-  extended: string,
+  extended: boolean,
+  withdeploy: boolean,
   version: string
 ): string {
-  const extendedStr = (extended: string): string => {
-    if (extended === 'true') {
+
+  const extendedStr = (extended: boolean): string => {
+    if (extended) {
       return 'extended_';
+    } else {
+      return '';
+      // } else {
+      //   throw new Error(`Invalid input (extended): ${extended}`);
+    }
+  };
+
+  const deployStr = (deploy: boolean): string => {
+    if (deploy) {
+      return 'withdeploy_';
     } else {
       return '';
       // } else {
@@ -22,7 +34,7 @@ export default function getURL(
     }
   };
 
-  const hugoName = `hugo_${extendedStr(extended)}${version}_${os}-${arch}`;
+  const hugoName = `hugo_${extendedStr(extended)}${deployStr(withdeploy)}${version}_${os}-${arch}`;
   const baseURL = 'https://github.com/gohugoio/hugo/releases/download';
   const url = `${baseURL}/v${version}/${hugoName}.${ext(os)}`;
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -44,8 +44,11 @@ export async function createBinDir(workDir: string): Promise<string> {
 }
 
 export async function installer(version: string): Promise<void> {
-  const extended: string = core.getInput('extended');
+  const extended: boolean = core.getInput('extended');
   core.debug(`Hugo extended: ${extended}`);
+
+  const withDeploy: boolean = core.getInput('withDeploy');
+  core.debug(`Hugo withDeploy: ${withDeploy}`);
 
   const osName: string = getOS(process.platform);
   core.debug(`Operating System: ${osName}`);
@@ -53,7 +56,7 @@ export async function installer(version: string): Promise<void> {
   const archName: string = getArch(process.arch);
   core.debug(`Processor Architecture: ${archName}`);
 
-  const toolURL: string = getURL(osName, archName, extended, version);
+  const toolURL: string = getURL(osName, archName, extended, withDeploy, version);
   core.debug(`toolURL: ${toolURL}`);
 
   const workDir = await createWorkDir();


### PR DESCRIPTION
## Brief summary

withDeploy argument allows users to install builds that support deployment to cloud infra which is essential in CI/CD pipeline.
